### PR TITLE
[main] Update `nextcloud/ocp` Dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -71,12 +71,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "5d6430816fd4afb6b87251b06e7eabcefba47610"
+                "reference": "9eff94dcc966d95c1f1621cad35f0d83160b42eb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/5d6430816fd4afb6b87251b06e7eabcefba47610",
-                "reference": "5d6430816fd4afb6b87251b06e7eabcefba47610",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/9eff94dcc966d95c1f1621cad35f0d83160b42eb",
+                "reference": "9eff94dcc966d95c1f1621cad35f0d83160b42eb",
                 "shasum": ""
             },
             "require": {
@@ -111,7 +111,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable32"
             },
-            "time": "2026-03-21T01:05:00+00:00"
+            "time": "2026-03-27T01:17:35+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency