### PR TITLE
Improve UI for Different Screen Sizes

### DIFF
--- a/src/components/ExportCsvButton.vue
+++ b/src/components/ExportCsvButton.vue
@@ -1,5 +1,5 @@
 <template>
-	<NcButton variant="primary" @click="onExportClick">
+	<NcButton :size="buttonSize" variant="primary" @click="onExportClick">
 		<template #icon>
 			<DownloadIcon />
 		</template>
@@ -13,6 +13,7 @@ import NcButton from '@nextcloud/vue/components/NcButton'
 import { DownloadIcon } from '@/icons/vue-material'
 import { showError } from '@nextcloud/dialogs'
 import { tryShowError } from '@/utils/errorHandling'
+import { useBreakpoints } from '@/composables/useBreakpoints'
 
 type TableExportRef = { exportAsCsv?: (fileName?: string) => boolean } | null
 
@@ -22,6 +23,7 @@ interface Props {
 
 const props = defineProps<Props>()
 
+const { buttonSize } = useBreakpoints()
 function onExportClick() {
 	// early check for export availability
 	if (!(props.tableRef && typeof props.tableRef.exportAsCsv === 'function')) {

--- a/src/components/FullPageTable.vue
+++ b/src/components/FullPageTable.vue
@@ -22,8 +22,10 @@ import { AllCommunityModule, LocaleModule } from 'ag-grid-community'
 import type { ColDef, GridOptions, GridApi, GridReadyEvent } from 'ag-grid-community'
 import { nextcloudTheme } from '../utils/agGridTheme'
 import { getAgGridLocaleText } from '../utils/agGridLocale'
+import { useBreakpoints } from '@/composables/useBreakpoints'
 
 const themeMode = ref<string>(isDarkTheme ? 'dark' : 'light')
+const { isMobile } = useBreakpoints()
 
 // Get AG Grid locale texts based on Nextcloud language
 const localeText = getAgGridLocaleText()
@@ -62,6 +64,9 @@ const gridOptions: GridOptions = {
 
 	// Row dragging
 	rowDragManaged: props.rowDragManaged || false,
+
+	// Disable column moving on mobile
+	suppressMovableColumns: isMobile.value,
 
 	// Column Sizing
 	autoSizeStrategy: {

--- a/src/components/Layout.vue
+++ b/src/components/Layout.vue
@@ -5,7 +5,7 @@
 		<NcAppContent>
 			<div class="app-content-wrapper">
 				<div class="app-content-header">
-					<h1 class="app-content-header__title">
+					<h1 class="app-content-header__title" :style="{fontSize: fontSize}">
 						{{ displayTitle }}
 					</h1>
 					<!-- Slot for right-aligned header actions (e.g. export button) -->
@@ -30,6 +30,9 @@ import NcContent from '@nextcloud/vue/components/NcContent'
 import NcAppContent from '@nextcloud/vue/components/NcAppContent'
 import Navigation from './Navigation.vue'
 import { generateFullTitle } from '@/navigation'
+import { useBreakpoints } from '@/composables/useBreakpoints'
+
+const { screenSizeCategory } = useBreakpoints()
 
 interface Props {
 	title?: string | null
@@ -42,6 +45,17 @@ const props = withDefaults(defineProps<Props>(), {
 // Compute display title from prop or fallback to app name
 const displayTitle = computed((): string => {
 	return props.title || 'Orchestra Scores Manager'
+})
+
+const fontSize = computed(() => {
+	switch (screenSizeCategory.value) {
+	case 'mobile':
+		return '18px'
+	case 'tablet':
+		return '20px'
+	default:
+		return '24px'
+	}
 })
 
 // Update document title when title prop changes
@@ -74,7 +88,6 @@ watch(() => props.title, (newTitle) => {
 
 .app-content-header__title {
 	margin: 0;
-	font-size: 24px;
 	font-weight: 600;
 	color: var(--color-main-text);
 	flex: 1 1 auto;

--- a/src/components/ScoresTable.vue
+++ b/src/components/ScoresTable.vue
@@ -51,6 +51,7 @@ import { useTagsStore } from '@/stores/tagsStore'
 import { useScoreSidebarStore } from '@/stores/scoreSidebarStore'
 import { spawnDialog } from '@nextcloud/vue/functions/dialog'
 import ConfirmationDialog from '@/components/ConfirmationDialog.vue'
+import { useBreakpoints } from '@/composables/useBreakpoints.ts'
 
 const gridModules = [TooltipModule]
 
@@ -88,6 +89,7 @@ const scoresStore = useScoresStore()
 const scoreBooksStore = useScoreBooksStore()
 const tagsStore = useTagsStore()
 const scoreSidebarStore = useScoreSidebarStore()
+const { columnPin } = useBreakpoints()
 
 // Ref to access FullPageTable exposed methods
 type TableExportRef = { exportAsCsv?: (fileName?: string) => boolean }
@@ -420,7 +422,7 @@ const columnDefs = computed<ColDef[]>(() => {
 	const cols: ColDef[] = [
 		{
 			headerName: '',
-			pinned: 'left' as const,
+			pinned: columnPin.value,
 			filter: false,
 			editable: false,
 			cellRenderer: markRaw(RowActionButton),
@@ -441,7 +443,7 @@ const columnDefs = computed<ColDef[]>(() => {
 		cols.push({
 			field: 'collectionIndex',
 			headerName: t('Index'),
-			pinned: 'left' as const,
+			pinned: columnPin.value,
 			filter: 'agNumberColumnFilter',
 			editable: false,
 			width: 100,
@@ -485,7 +487,7 @@ const columnDefs = computed<ColDef[]>(() => {
 	// Title column with optional icon renderer
 	const titleColumn: ColDef = {
 		field: 'title',
-		pinned: 'left' as const,
+		pinned: columnPin.value,
 		headerName: t('Title'),
 		...(props.folderCollectionScores && hasScoreBooks.value
 			? {

--- a/src/composables/useBreakpoints.ts
+++ b/src/composables/useBreakpoints.ts
@@ -1,0 +1,69 @@
+import { computed, type Ref, ref, onUnmounted } from 'vue'
+
+const useMediaQueryComposable = (query: string): Ref<boolean> => {
+	const matches = ref(window.matchMedia(query).matches)
+	const mq = window.matchMedia(query)
+
+	const handler = (event: MediaQueryListEvent) => {
+		matches.value = event.matches
+	}
+
+	mq.addEventListener('change', handler)
+	onUnmounted(() => mq.removeEventListener('change', handler))
+
+	return matches
+}
+
+export const useBreakpoints = () => {
+	// Base OrUp refs (matchMedia)
+	const isSmOrUp = useMediaQueryComposable('(min-width: 640px)')
+	const isMdOrUp = useMediaQueryComposable('(min-width: 768px)')
+	const isLgOrUp = useMediaQueryComposable('(min-width: 1024px)')
+	const isXlOrUp = useMediaQueryComposable('(min-width: 1280px)')
+	const is2xlOrUp = useMediaQueryComposable('(min-width: 1536px)')
+
+	// OrDown (computed inverses)
+	const isSmOrDown = computed(() => !isSmOrUp.value)
+	const isMdOrDown = computed(() => !isMdOrUp.value)
+	const isLgOrDown = computed(() => !isLgOrUp.value)
+	const isXlOrDown = computed(() => !isXlOrUp.value)
+	const is2xlOrDown = computed(() => !is2xlOrUp.value)
+
+	// High level helpers
+	const isMobile = computed(() => isMdOrDown.value)
+	const isTablet = computed(() => isLgOrDown.value && !isMobile.value)
+	const isDesktop = computed(() => isLgOrUp.value)
+	const screenSizeCategory = computed(() =>
+		isMobile.value ? 'mobile' : isTablet.value ? 'tablet' : 'desktop',
+	)
+
+	// Component helpers
+	const columnPin = computed(() => isMobile.value ? false : 'left')
+	const buttonSize = computed(() => isDesktop.value ? 'normal' : 'small')
+
+	return {
+		// OrUp (reactive refs)
+		isSmOrUp,
+		isMdOrUp,
+		isLgOrUp,
+		isXlOrUp,
+		is2xlOrUp,
+
+		// OrDown
+		isSmOrDown,
+		isMdOrDown,
+		isLgOrDown,
+		isXlOrDown,
+		is2xlOrDown,
+
+		// High level helpers
+		isMobile,
+		isTablet,
+		isDesktop,
+		screenSizeCategory,
+
+		// Component helpers
+		columnPin,
+		buttonSize,
+	}
+}

--- a/src/pages/foldercollection/components/AddToCollectionButton.vue
+++ b/src/pages/foldercollection/components/AddToCollectionButton.vue
@@ -1,5 +1,8 @@
 <template>
-	<NcButton v-if="editable" variant="primary" @click="openDialog">
+	<NcButton v-if="editable"
+		:size="buttonSize"
+		variant="primary"
+		@click="openDialog">
 		<template #icon>
 			<AddIcon />
 		</template>
@@ -86,6 +89,7 @@ import {
 import { useScoresStore } from '@/stores/scoresStore'
 import { useScoreBooksStore } from '@/stores/scoreBooksStore'
 import type { Score, ScoreIndexed, ScoreBook, ScoreBookIndexed } from '@/api/generated/openapi/data-contracts'
+import { useBreakpoints } from '@/composables/useBreakpoints'
 
 interface Props {
 	editable: boolean
@@ -110,6 +114,7 @@ interface TypeOption {
 
 const scoresStore = useScoresStore()
 const scoreBooksStore = useScoreBooksStore()
+const { buttonSize } = useBreakpoints()
 
 const showDialog = ref(false)
 const loadingData = ref(false)

--- a/src/pages/foldercollection/components/ExportTocButton.vue
+++ b/src/pages/foldercollection/components/ExportTocButton.vue
@@ -1,5 +1,5 @@
 <template>
-	<NcButton variant="primary" @click="onExportClick">
+	<NcButton variant="primary" :size="buttonSize" @click="onExportClick">
 		<template #icon>
 			<DownloadIcon />
 		</template>
@@ -14,6 +14,7 @@ import { DownloadIcon } from '@/icons/vue-material'
 import { tryShowError } from '@/utils/errorHandling'
 import { exportFolderCollectionToXlsx, type CollectionEntry } from '@/utils/xlsx-exporter'
 import type { FolderCollection, FolderCollectionVersion } from '@/api/generated/openapi/data-contracts'
+import { useBreakpoints } from '@/composables/useBreakpoints'
 
 interface Props {
 	folderCollection: FolderCollection
@@ -22,6 +23,8 @@ interface Props {
 }
 
 const props = defineProps<Props>()
+
+const { buttonSize } = useBreakpoints()
 
 /**
  * Handle export button click

--- a/src/pages/foldercollection/components/StartNewVersionButton.vue
+++ b/src/pages/foldercollection/components/StartNewVersionButton.vue
@@ -2,6 +2,7 @@
 	<NcButton
 		:aria-label="t('Start new version')"
 		:disabled="disabled"
+		:size="buttonSize"
 		@click="handleStartNewVersion">
 		<template #icon>
 			<HistoryIcon :size="20" />
@@ -21,6 +22,7 @@ import { t } from '@/utils/l10n'
 import { useFolderCollectionVersionsStore } from '@/stores/folderCollectionVersionsStore'
 import { useFolderCollectionsStore } from '@/stores/folderCollectionsStore'
 import type { FolderCollectionVersion } from '@/api/generated/openapi/data-contracts'
+import { useBreakpoints } from '@/composables/useBreakpoints'
 
 interface Props {
 	folderCollectionId: number
@@ -37,6 +39,7 @@ const emit = defineEmits<{
 
 const versionsStore = useFolderCollectionVersionsStore()
 const folderCollectionsStore = useFolderCollectionsStore()
+const { buttonSize } = useBreakpoints()
 
 /**
  * Handle start new version button click

--- a/src/pages/foldercollections/components/AddFolderCollectionButton.vue
+++ b/src/pages/foldercollections/components/AddFolderCollectionButton.vue
@@ -1,5 +1,8 @@
 <template>
-	<NcButton v-if="editable" variant="primary" @click="showCreateDialog = true">
+	<NcButton v-if="editable"
+		:size="buttonSize"
+		variant="primary"
+		@click="showCreateDialog = true">
 		<template #icon>
 			<AddIcon />
 		</template>
@@ -47,6 +50,7 @@ import { showError, showSuccess } from '@nextcloud/dialogs'
 import { tryShowError } from '@/utils/errorHandling'
 import AddOrEditDialog from '@/components/AddOrEditDialog.vue'
 import { useFolderCollectionsStore } from '@/stores/folderCollectionsStore'
+import { useBreakpoints } from '@/composables/useBreakpoints'
 
 interface Props {
 	editable: boolean
@@ -55,6 +59,7 @@ interface Props {
 defineProps<Props>()
 
 const folderCollectionsStore = useFolderCollectionsStore()
+const { buttonSize } = useBreakpoints()
 
 interface CollectionTypeOption {
 	label: string

--- a/src/pages/scorebook/components/AddScoreToBookButton.vue
+++ b/src/pages/scorebook/components/AddScoreToBookButton.vue
@@ -1,5 +1,8 @@
 <template>
-	<NcButton v-if="editable" variant="primary" @click="openDialog">
+	<NcButton v-if="editable"
+		:size="buttonSize"
+		variant="primary"
+		@click="openDialog">
 		<template #icon>
 			<AddIcon />
 		</template>
@@ -56,6 +59,7 @@ import {
 import { useScoresStore } from '@/stores/scoresStore'
 import { useScoreBooksStore } from '@/stores/scoreBooksStore'
 import type { Score } from '@/api/generated/openapi/data-contracts'
+import { useBreakpoints } from '@/composables/useBreakpoints.ts'
 
 interface Props {
 	editable: boolean
@@ -72,6 +76,7 @@ const emit = defineEmits<{
 
 const scoresStore = useScoresStore()
 const scoreBooksStore = useScoreBooksStore()
+const { buttonSize } = useBreakpoints()
 
 const showDialog = ref(false)
 const loadingScores = ref(false)

--- a/src/pages/scorebooks/components/AddScoreBookButton.vue
+++ b/src/pages/scorebooks/components/AddScoreBookButton.vue
@@ -1,5 +1,8 @@
 <template>
-	<NcButton v-if="editable" variant="primary" @click="showCreateDialog = true">
+	<NcButton v-if="editable"
+		:size="buttonSize"
+		variant="primary"
+		@click="showCreateDialog = true">
 		<template #icon>
 			<AddIcon />
 		</template>
@@ -26,6 +29,7 @@ import { showError, showSuccess } from '@nextcloud/dialogs'
 import { tryShowError } from '@/utils/errorHandling'
 import AddOrEditDialog from '@/components/AddOrEditDialog.vue'
 import { useScoreBooksStore } from '@/stores/scoreBooksStore'
+import { useBreakpoints } from '@/composables/useBreakpoints'
 
 interface Props {
 	editable: boolean
@@ -34,6 +38,7 @@ interface Props {
 defineProps<Props>()
 
 const scoreBooksStore = useScoreBooksStore()
+const { buttonSize } = useBreakpoints()
 
 const showCreateDialog = ref(false)
 const inputNewScoreBookTitle = ref('')

--- a/src/pages/scorebooks/components/ScoreBooksTable.vue
+++ b/src/pages/scorebooks/components/ScoreBooksTable.vue
@@ -20,6 +20,7 @@ import type { ColDef, CellValueChangedEvent } from 'ag-grid-community'
 import { useScoreBooksStore } from '@/stores/scoreBooksStore'
 import { useTagsStore } from '@/stores/tagsStore'
 import type { ScoreBook } from '@/api/generated/openapi/data-contracts'
+import { useBreakpoints } from '@/composables/useBreakpoints.ts'
 
 interface Props {
 	editable: boolean
@@ -29,6 +30,8 @@ const props = defineProps<Props>()
 
 const scoreBooksStore = useScoreBooksStore()
 const tagsStore = useTagsStore()
+
+const { columnPin } = useBreakpoints()
 
 // Ref to access FullPageTable exposed methods
 type TableExportRef = { exportAsCsv?: (fileName?: string) => boolean }
@@ -86,7 +89,7 @@ async function handleCellValueChanged(event: CellValueChangedEvent) {
 const columnDefs = ref<ColDef[]>([
 	{
 		headerName: '',
-		pinned: 'left' as const,
+		pinned: columnPin.value,
 		filter: false,
 		editable: false,
 		cellRenderer: markRaw(RowActionButton),
@@ -105,7 +108,7 @@ const columnDefs = ref<ColDef[]>([
 		resizable: false,
 		suppressMovable: true,
 	},
-	{ field: 'title', headerName: t('Title') },
+	{ field: 'title', headerName: t('Title'), sort: 'asc' },
 	{ field: 'titleShort', headerName: t('Short Title') },
 	{ field: 'composer', headerName: t('Composer') },
 	{ field: 'arranger', headerName: t('Arranger') },

--- a/src/pages/scores/components/AddScoreButton.vue
+++ b/src/pages/scores/components/AddScoreButton.vue
@@ -1,5 +1,9 @@
 <template>
-	<NcButton v-if="editable" variant="primary" @click="showCreateDialog = true">
+	<NcButton
+		v-if="editable"
+		:size="buttonSize"
+		variant="primary"
+		@click="showCreateDialog = true">
 		<template #icon>
 			<AddIcon />
 		</template>
@@ -26,6 +30,7 @@ import { showError, showSuccess } from '@nextcloud/dialogs'
 import { tryShowError } from '@/utils/errorHandling'
 import AddOrEditDialog from '@/components/AddOrEditDialog.vue'
 import { useScoresStore } from '@/stores/scoresStore'
+import { useBreakpoints } from '@/composables/useBreakpoints'
 
 interface Props {
 	editable: boolean
@@ -37,6 +42,7 @@ const scoresStore = useScoresStore()
 
 const showCreateDialog = ref(false)
 const inputNewScoreTitle = ref('')
+const { buttonSize } = useBreakpoints()
 
 const isFormValid = computed(() => inputNewScoreTitle.value.trim().length > 0)
 

--- a/src/pages/setlist/Index.vue
+++ b/src/pages/setlist/Index.vue
@@ -15,6 +15,7 @@
 				:get-columns="getPdfColumns" />
 			<NcButton
 				v-if="setlist && editable"
+				:size="buttonSize"
 				variant="primary"
 				@click="showCloneDialog = true">
 				<template #icon>
@@ -24,6 +25,7 @@
 			</NcButton>
 			<NcButton
 				variant="primary"
+				:size="buttonSize"
 				@click="handleDetailsButtonClick()">
 				<template #icon>
 					<InfoIcon :size="20" />
@@ -89,6 +91,7 @@ import { apiClients } from '@/api/client'
 import type { Setlist, Score, ScoreIndexed, FolderCollection, ScoreBookIndexed } from '@/api/generated/openapi/data-contracts'
 import { useScoreSidebarStore } from '@/stores/scoreSidebarStore'
 import type { PdfColumnConfig } from '@/utils/pdf-exporter'
+import { useBreakpoints } from '@/composables/useBreakpoints'
 
 const route = useRoute()
 const setlistsStore = useSetlistsStore()
@@ -97,6 +100,7 @@ const setlistEntriesStore = useSetlistEntriesStore()
 const scoreSidebarStore = useScoreSidebarStore()
 const scoresStore = useScoresStore()
 const scoreBooksStore = useScoreBooksStore()
+const { buttonSize } = useBreakpoints()
 
 const loading = ref(false)
 const loadError = ref(false)

--- a/src/pages/setlist/components/AddSetlistEntryButton.vue
+++ b/src/pages/setlist/components/AddSetlistEntryButton.vue
@@ -1,5 +1,5 @@
 <template>
-	<NcButton variant="primary" @click="showDialog = true">
+	<NcButton variant="primary" :size="buttonSize" @click="showDialog = true">
 		<template #icon>
 			<AddIcon :size="20" />
 		</template>
@@ -77,6 +77,7 @@ import { useScoresStore } from '@/stores/scoresStore'
 import { parseDurationHHMMSS, formatDurationHHMMSS, restrictToTimeFormat as restrictInputToTimeFormat } from '@/utils/timeFormatUtils'
 import type { Setlist, Score, ScoreIndexed } from '@/api/generated/openapi/data-contracts'
 import { apiClients } from '@/api/client'
+import { useBreakpoints } from '@/composables/useBreakpoints'
 
 interface Props {
 	setlist: Setlist
@@ -87,6 +88,7 @@ const props = defineProps<Props>()
 
 const setlistEntriesStore = useSetlistEntriesStore()
 const scoresStore = useScoresStore()
+const { buttonSize } = useBreakpoints()
 
 const showDialog = ref(false)
 

--- a/src/pages/setlist/components/ExportPdfButton.vue
+++ b/src/pages/setlist/components/ExportPdfButton.vue
@@ -1,5 +1,5 @@
 <template>
-	<NcButton variant="primary" @click="openDialog">
+	<NcButton variant="primary" :size="buttonSize" @click="openDialog">
 		<template #icon>
 			<DownloadIcon />
 		</template>
@@ -63,6 +63,7 @@ import type { PdfColumnConfig, PdfColumnId } from '@/utils/pdf-exporter'
 import { useScoresStore } from '@/stores/scoresStore'
 import { useScoreBooksStore } from '@/stores/scoreBooksStore'
 import type { Setlist, SetlistEntry, FolderCollection } from '@/api/generated/openapi/data-contracts'
+import { useBreakpoints } from '@/composables/useBreakpoints'
 
 interface Props {
 	setlist: Setlist
@@ -78,6 +79,7 @@ const props = defineProps<Props>()
 
 const scoresStore = useScoresStore()
 const scoreBooksStore = useScoreBooksStore()
+const { buttonSize } = useBreakpoints()
 
 /** Column IDs that are enabled by default in the export dialog */
 const DEFAULT_ENABLED_IDS: ReadonlySet<PdfColumnId> = new Set([

--- a/src/pages/setlist/components/SetlistEntriesTable.vue
+++ b/src/pages/setlist/components/SetlistEntriesTable.vue
@@ -35,6 +35,7 @@ import type { PdfColumnConfig, PdfColumnId } from '@/utils/pdf-exporter'
 import { isBreakEntry, resolveScoreField } from '@/utils/setlistScoreUtils'
 import type { ScoreInfoField } from '@/utils/setlistScoreUtils'
 import { showError } from '@nextcloud/dialogs'
+import { useBreakpoints } from '@/composables/useBreakpoints'
 
 const gridModules = [
 	ClientSideRowModelModule,
@@ -64,6 +65,8 @@ const props = defineProps<Props>()
 const scoresStore = useScoresStore()
 const scoreBooksStore = useScoreBooksStore()
 const setlistEntriesStore = useSetlistEntriesStore()
+
+const { columnPin } = useBreakpoints()
 
 // Ref to access FullPageTable exposed methods
 type TableExportRef = { exportAsCsv?: (fileName?: string) => boolean; getGridApi?: () => GridApi | null }
@@ -305,7 +308,7 @@ const columnDefs = computed<ColDef[]>(() => {
 	const cols: ColDef[] = [
 		{
 			headerName: '',
-			pinned: 'left' as const,
+			pinned: columnPin.value,
 			filter: false,
 			editable: false,
 			sortable: false,

--- a/src/pages/setlists/components/AddSetlistButton.vue
+++ b/src/pages/setlists/components/AddSetlistButton.vue
@@ -1,5 +1,8 @@
 <template>
-	<NcButton v-if="editable" variant="primary" @click="showCreateDialog = true">
+	<NcButton v-if="editable"
+		:size="buttonSize"
+		variant="primary"
+		@click="showCreateDialog = true">
 		<template #icon>
 			<AddIcon />
 		</template>
@@ -76,6 +79,7 @@ import { AddIcon, ConfirmIcon, CancelIcon } from '@/icons/vue-material'
 import { showError, showSuccess } from '@nextcloud/dialogs'
 import { tryShowError } from '@/utils/errorHandling'
 import { useSetlistsStore } from '@/stores/setlistsStore'
+import { useBreakpoints } from '@/composables/useBreakpoints'
 
 interface Props {
 	editable: boolean
@@ -84,6 +88,7 @@ interface Props {
 defineProps<Props>()
 
 const setlistsStore = useSetlistsStore()
+const { buttonSize } = useBreakpoints()
 
 const showCreateDialog = ref(false)
 const titleError = ref(false)


### PR DESCRIPTION
* Change Page Title and Header Actions Size based on Screen Size
* Don't Pin Column on Narrow Screens (pinned columns take up too much horizontal space)
* Don't allow Column-Reorder on Narrow Screens (reordering happens easily by accident on touchscreens)